### PR TITLE
Update CI Job Names and Add Docs Build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
         pip install pytest
         pytest go_utils
   format:
-    name: Black Formatter Test
+    name: Format
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
         pip install black
         black --check --diff ./
   lint:
-    name: Run Flake8 Linter
+    name: Lint
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -49,7 +49,25 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - name: Lint
+    - name: Run Flake8 Linter
       run: |
         pip install flake8
         flake8
+  docs:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Generate Docs
+      run: |
+        pip install -e .
+        pip install pdoc
+        pdoc --t doc_template --docformat numpy -o globe-observer-utils-docs go_utils/.
+    - uses: actions/upload-artifact@v2
+      with:
+        name: docs-build
+        path: globe-observer-utils-docs/


### PR DESCRIPTION
Now builds documentation during the CI phase (ensures there are no errors) and uploads the generated HTML files as an artifact to Github if further review is needed. 