### PR TITLE
Add fix to new GLOBETeams column

### DIFF
--- a/go_utils/cleanup.py
+++ b/go_utils/cleanup.py
@@ -67,9 +67,12 @@ def remove_homogenous_cols(df):
     """
 
     for column in df.columns:
-        if len(pd.unique(df[column])) == 1:
-            logging.info(f"Dropped: {df[column][0]}")
-            df.drop(column, axis=1, inplace=True)
+        try:
+            if len(pd.unique(df[column])) == 1:
+                logging.info(f"Dropped: {df[column][0]}")
+                df.drop(column, axis=1, inplace=True)
+        except TypeError:
+            continue
 
 
 def replace_column_prefix(df, protocol, replacement_text):


### PR DESCRIPTION
GLOBE added a new column (e.g. mosquitohabitatmapperGlobeTeams) that uses lists. Lists aren't hashable which ultimately causes some of the cleanup methods to crash. This fixes that.