### PR TITLE
Fix photo download naming bug

### DIFF
--- a/go_utils/cli.py
+++ b/go_utils/cli.py
@@ -2,7 +2,7 @@ import argparse
 import matplotlib.pyplot as plt
 import pandas as pd
 
-from go_utils.download import get_api_data
+from go_utils.download import get_api_data, convert_dates_to_datetime
 from go_utils.geoenrich import get_country_api_data
 from go_utils import mhm, lc
 from go_utils.photo_download import download_mhm_photos, download_lc_photos
@@ -205,6 +205,7 @@ def mhm_photo_download():
         download_args["abdomen_photo"] = ""
 
     df = pd.read_csv(args.input)
+    convert_dates_to_datetime(df)
 
     if args.all:
         download_mhm_photos(df, args.out)
@@ -253,6 +254,7 @@ def lc_photo_download():
         download_args["west_photo"] = ""
 
     df = pd.read_csv(args.input)
+    convert_dates_to_datetime(df)
 
     if args.all:
         download_lc_photos(df, args.out)

--- a/go_utils/download.py
+++ b/go_utils/download.py
@@ -86,14 +86,14 @@ def get_api_data(
 
     # Convert measured date data into datetime
     df = parse_api_data(response.json())
-    convert_dates_to_datetime(df, protocol)
+    convert_dates_to_datetime(df)
 
     if is_clean:
         df = default_data_clean(df, protocol)
     return df
 
 
-def convert_dates_to_datetime(df, protocol):
+def convert_dates_to_datetime(df):
     date_columns = [col for col in df.columns if "Date" in col or "MeasuredAt" in col]
     for column in date_columns:
         df[column] = pd.to_datetime(df[column], errors="coerce")

--- a/go_utils/geoenrich.py
+++ b/go_utils/geoenrich.py
@@ -82,7 +82,7 @@ def get_country_api_data(
     end = datetime.strptime(end_date, "%Y-%m-%d")
     measured_at = protocol.replace("_", "") + "MeasuredAt"
 
-    convert_dates_to_datetime(df, protocol)
+    convert_dates_to_datetime(df)
 
     df = df[(df[measured_at] >= start) & (df[measured_at] <= end)]
 

--- a/go_utils/photo_download.py
+++ b/go_utils/photo_download.py
@@ -110,6 +110,7 @@ def get_mhm_download_targets(
             return
 
         urls = url_entry.split(";")
+        date_str = pd.to_datetime(str(date)).strftime("%Y-%m-%d")
         for url in urls:
             if pd.isna(url) or "https" not in url:
                 continue
@@ -120,21 +121,19 @@ def get_mhm_download_targets(
                 classification = "None"
             elif not pd.isna(species):
                 classification = f"{classification} {species}"
-
-            name = f"mhm-{url_type}-{watersource}-{date}-{mhm_id}-{classification}-{photo_id}.png"
+            name = f"mhm-{url_type}-{watersource}-{date_str}-{mhm_id}-{classification}-{photo_id}.png"
 
             targets.add((url, directory, name))
 
     photo_locations = {k: v for k, v in arguments.items() if "photo" in k}
     for param_name, column_name in photo_locations.items():
         if column_name:
-
             get_mosquito_args = np.vectorize(get_photo_args)
             get_mosquito_args(
                 mhm_df[column_name].to_numpy(),
                 _format_param_name(param_name),
                 mhm_df[watersource_col].to_numpy(),
-                mhm_df[date_col].to_numpy(),
+                mhm_df[date_col],
                 mhm_df[id_col].to_numpy(),
                 mhm_df[genus_col].to_numpy(),
                 mhm_df[species_col].to_numpy() if species_col else "",
@@ -241,10 +240,10 @@ def get_lc_download_targets(
     def get_photo_args(url, direction, date, lc_id):
         if pd.isna(url) or "https" not in url:
             return
-
+        date_str = pd.to_datetime(str(date)).strftime("%Y-%m-%d")
         photo_id = get_globe_photo_id(url)
 
-        name = f"lc-{direction}-{date}-{lc_id}-{photo_id}.png"
+        name = f"lc-{direction}-{date_str}-{lc_id}-{photo_id}.png"
 
         targets.add((url, directory, name))
 
@@ -255,7 +254,7 @@ def get_lc_download_targets(
             get_lc_photo_args(
                 lc_df[column_name].to_numpy(),
                 _format_param_name(param_name),
-                lc_df[date_col].to_numpy(),
+                lc_df[date_col],
                 lc_df[id_col].to_numpy(),
             )
 

--- a/go_utils/tests/photo_download_test.py
+++ b/go_utils/tests/photo_download_test.py
@@ -2,6 +2,8 @@ import pytest
 import pandas as pd
 import shutil
 
+from go_utils.download import convert_dates_to_datetime
+
 from go_utils.photo_download import (
     get_mhm_download_targets,
     get_lc_download_targets,
@@ -84,6 +86,7 @@ desired_lc_names = [
 )
 def test_naming(input_file, func, desired):
     df = pd.read_csv(input_file)
+    convert_dates_to_datetime(df)
 
     targets = func(df, "")
     success = True
@@ -112,6 +115,7 @@ def test_naming(input_file, func, desired):
 def photodownload_setup(request):
     input_file, func = request.param
     df = pd.read_csv(input_file)
+    convert_dates_to_datetime(df)
     yield df, func
     shutil.rmtree(out_directory)
 


### PR DESCRIPTION
Due to converting date values to datetime, there were weird bugs occurring in the naming of photos when being downloaded.