### PR TITLE
Add Python 3.10 and lower arcgis to 1.8.4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, '3.10']
     name: Test - ${{ matrix.os }}, ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         "numpy>=1.19.0",
         "pandas>=1.1.5",
         "requests>=2.23.0",
-        "arcgis==1.9.1",
+        "arcgis==1.8.4",
         "seaborn>=0.11.1",
         "pytz>=2021.3",
         "timezonefinder>=5.2.0",


### PR DESCRIPTION
It seems like on python 3.10, there's a bug for arcgis 1.9.1 for windows, so by lowering the version it should resolve that issue.