### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         "numpy>=1.19.0",
         "pandas>=1.1.5",
         "requests>=2.23.0",
-        "arcgis==1.9.1",
+        "arcgis==1.8.4",
         "seaborn>=0.11.1",
         "pytz>=2021.3",
         "timezonefinder>=5.2.0",


### PR DESCRIPTION
PR to re-run CI checks and verify success using arcgis pinned to 1.8.4, without adding Python 3.10. 

Note that even ArcGIS 2.10.0.2 requires Python <3.10 (https://pypi.org/project/arcgis/2.1.0.2/)